### PR TITLE
feat: add policy settings in all usages

### DIFF
--- a/examples/custom_rules/main.tf
+++ b/examples/custom_rules/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }
@@ -25,6 +25,11 @@ module "policy" {
     name           = module.naming.web_application_firewall_policy.name
     resource_group = module.rg.groups.demo.name
     location       = module.rg.groups.demo.location
+
+    policy_settings = {
+      enabled = true
+      mode    = "Prevention"
+    }
 
     managed_rules = {
       managed_rule_sets = {

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }

--- a/examples/managed-rules/main.tf
+++ b/examples/managed-rules/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }
@@ -25,6 +25,11 @@ module "policy" {
     name           = module.naming.web_application_firewall_policy.name
     resource_group = module.rg.groups.demo.name
     location       = "westeurope"
+
+    policy_settings = {
+      enabled = true
+      mode    = "Prevention"
+    }
 
     managed_rules = {
       managed_rule_sets = {


### PR DESCRIPTION
## Description

This PR adds policy settings in all usages.

```
    deploy_test.go:165: All modules applied and destroyed successfully.
--- PASS: TestApplyAllParallel (0.00s)
    --- PASS: TestApplyAllParallel/custom_rules (184.12s)
    --- PASS: TestApplyAllParallel/default (184.82s)
    --- PASS: TestApplyAllParallel/managed-rules (186.27s)
PASS
ok      github.com/cloudnationhq/terraform-azure-wafwp  186.600s
```

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)