### PR TITLE
fix: log_scrubbing wired into policy_settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Claude Code
+.claude

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.72.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:AymDoYag6FI+U2Q89QXJM9oJlHr8c/0d4laM4A/nnk8=",
+    "zh:073472587c3752e89738522814d2b4eb2fd69eb2cb19c5a5ead3c7d2eabdc279",
+    "zh:1950effc0c315b6002c8cb6327b94fe59bda210e699367d9727bc66490d651d2",
+    "zh:47c990db75658525de57c8955a05b4752b88f3a900fffac0e7661d4a749e94f2",
+    "zh:610f2cbd6fab76750d8b093f03beabbb7162dc8c6affe0109f534ce240b3ff0f",
+    "zh:6739d645fe548c5a489d711f7748f32368cf68d723d2c59d3f2e21456304d692",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a277ab095cc8aff3aede9e43eca2a699936472ef90abb272adf3daa609eb9141",
+    "zh:b1fdcdaf926c86de0d884beda90d78cb94a42ddede03a1f0b92c36b321d4f07e",
+    "zh:c003f1f15e52c54e189301ae2c7d8dd65acb2e5a7527d201355f2757b5465ba9",
+    "zh:c45f2d2206c0f8f71f207cd39eec73da9619d35932bbe1a5b8be7679c50a151e",
+    "zh:d7040d8ec295481bc1d30346ed7f3075c40ede87c0fedf1db34dd91c1c367a10",
+    "zh:e595f0b870cd5fd5debdc926fc1740201d2b66188b9b132dc598bdd6444e7348",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (~> 4.0)
+- <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (4.72.0)
 
 ## Resources
 
@@ -67,6 +67,15 @@ object({
       request_body_inspect_limit_in_kb          = optional(number, 128)
       js_challenge_cookie_expiration_in_minutes = optional(number, 30)
       file_upload_enforcement                   = optional(bool, null)
+      log_scrubbing = optional(object({
+        enabled = optional(bool)
+        rules = optional(map(object({
+          enabled                 = optional(bool)
+          match_variable          = string
+          selector_match_operator = optional(string, "Equals")
+          selector                = optional(string)
+        })), {})
+      }))
     }), null)
     custom_rules = optional(map(object({
       action               = string

--- a/examples/managed-rules/main.tf
+++ b/examples/managed-rules/main.tf
@@ -28,6 +28,15 @@ module "policy" {
     policy_settings = {
       enabled = true
       mode    = "Prevention"
+
+      log_scrubbing = {
+        rules = {
+          scrub_auth_header = {
+            match_variable = "RequestHeaderNames"
+            selector       = "Authorization"
+          }
+        }
+      }
     }
     managed_rules = {
       managed_rule_sets = {

--- a/main.tf
+++ b/main.tf
@@ -31,15 +31,13 @@ resource "azurerm_web_application_firewall_policy" "this" {
       file_upload_enforcement                   = policy_settings.value.file_upload_enforcement
 
       dynamic "log_scrubbing" {
-        for_each = try(policy_settings.value.log_scrubbing, null) != null ? [policy_settings.value.log_scrubbing] : []
+        for_each = policy_settings.value.log_scrubbing != null ? { "this" = policy_settings.value.log_scrubbing } : {}
 
         content {
           enabled = log_scrubbing.value.enabled
 
           dynamic "rule" {
-            for_each = try(
-              log_scrubbing.value.rules, []
-            )
+            for_each = log_scrubbing.value.rules
 
             content {
               enabled                 = rule.value.enabled

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,15 @@ variable "config" {
       request_body_inspect_limit_in_kb          = optional(number, 128)
       js_challenge_cookie_expiration_in_minutes = optional(number, 30)
       file_upload_enforcement                   = optional(bool, null)
+      log_scrubbing = optional(object({
+        enabled = optional(bool)
+        rules = optional(map(object({
+          enabled                 = optional(bool)
+          match_variable          = string
+          selector_match_operator = optional(string, "Equals")
+          selector                = optional(string)
+        })), {})
+      }))
     }), null)
     custom_rules = optional(map(object({
       action               = string
@@ -73,6 +82,7 @@ variable "config" {
     condition     = var.config.resource_group_name != null || var.resource_group_name != null
     error_message = "resource group name must be provided either in the object or as a separate variable."
   }
+
 }
 
 variable "resource_group_name" {


### PR DESCRIPTION
## Description

log_scrubbing field added to main.tf, but not in variable type definition, resulting in the module silently dropping the field. It has been added to the type definition now using map iteration

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Change Log

Below please provide what should go into the changelog (if anything)

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_web_application_firewall_policy` - support for the `log_scrubbing` property within `policy_settings`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #39 
